### PR TITLE
Add shuffle tests and export function

### DIFF
--- a/memorymatch.js
+++ b/memorymatch.js
@@ -1,5 +1,20 @@
 // ===== Memory Match (standalone block) =====
-(() => {
+(function () {
+  function shuffle(arr) {
+    const a = [...arr];
+    for (let i = a.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [a[i], a[j]] = [a[j], a[i]];
+    }
+    return a;
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { shuffle };
+  }
+
+  if (typeof document === 'undefined') return;
+
   const $ = id => document.getElementById(id);
 
   // Required elements
@@ -16,15 +31,6 @@
   let secondCard = null;
   let lockBoard = false;
   let matches = 0;
-
-  // Helpers
-  function shuffle(a) {
-    for (let i = a.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [a[i], a[j]] = [a[j], a[i]];
-    }
-    return a;
-  }
 
   function speakKana(char) {
     try {

--- a/memorymatch.test.js
+++ b/memorymatch.test.js
@@ -1,0 +1,28 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { shuffle } = require('./memorymatch.js');
+
+describe('shuffle', () => {
+  test('returns a permutation of the input', () => {
+    const input = [1, 2, 3, 4, 5];
+    const result = shuffle(input);
+    assert.deepStrictEqual([...result].sort(), [...input].sort());
+  });
+
+  test('does not mutate the original array', () => {
+    const input = [1, 2, 3, 4, 5];
+    const copy = [...input];
+    shuffle(input);
+    assert.deepStrictEqual(input, copy);
+  });
+
+  test('produces different orderings on multiple runs', () => {
+    const input = Array.from({ length: 10 }, (_, i) => i);
+    const results = new Set();
+    for (let i = 0; i < 5; i++) {
+      results.add(shuffle(input).join(','));
+    }
+    assert.ok(results.size > 1);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "langylearner",
+  "version": "1.0.0",
+  "description": "",
+  "main": "lesson-loader.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- refactor `shuffle` to avoid mutating input and safely export for Node tests
- add Node-based test suite for `shuffle`
- configure package.json to run tests with Node's test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af01bc080c8322b1da27543a4b22cc